### PR TITLE
Support using  `backgroundColor='transparent'`

### DIFF
--- a/packages/react-ruler/src/react-ruler/Ruler.tsx
+++ b/packages/react-ruler/src/react-ruler/Ruler.tsx
@@ -76,9 +76,17 @@ export default class Ruler extends React.PureComponent<RulerProps> implements Ru
         const isHorizontal = type === "horizontal";
         const isDirectionStart = direction === "start";
 
-        context.rect(0, 0, width * 2, height * 2);
-        context.fillStyle = backgroundColor;
-        context.fill();
+        if (backgroundColor === 'transparent') {
+            // Clear existing paths & text
+            context.clearRect(0, 0, width * 2, height * 2);        
+        }
+        else {
+            // Draw the background
+            context.rect(0, 0, width * 2, height * 2);
+            context.fillStyle = backgroundColor;
+            context.fill();
+        }
+        
         context.save();
         context.scale(2, 2);
         context.strokeStyle = lineColor;


### PR DESCRIPTION
When the background color is set to `transparent`, the existing paths & text are not cleared - resulting in the draw method appending paths to the canvas on each draw. This change clears existing paths and text when the `backgroundColor` is set to `transparent` to result in a clean and correct render when the background is transparent.